### PR TITLE
Allow relabeling of the service monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support to relabel metrics from the service monitor.
+
 ## [0.1.3] - 2022-10-19
 
 ### Added

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/servicemonitor.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -6,11 +7,32 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  selector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   endpoints:
   - interval: 30s
     port: web
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.serviceMonitor.metricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ tpl (toYaml .Values.serviceMonitor.relabelings | indent 4) . }}
+{{- end }}
   - interval: 30s
     port: reloader-web
-  selector:
-    matchLabels:
-      {{- include "labels.selector" . | nindent 6 -}}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.serviceMonitor.metricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ tpl (toYaml .Values.serviceMonitor.relabelings | indent 4) . }}
+{{- end }}
+{{- end }}

--- a/helm/prometheus-agent/charts/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/values.yaml
@@ -18,6 +18,28 @@ remoteWrite: []
 
 externalLabels: {}
 
+serviceMonitor:
+  enabled: true
+  jobLabel: prometheus-agent
+  ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
+  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+  ##
+  metricRelabelings: []
+  # - action: keep
+  #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+  #   sourceLabels: [__name__]
+
+  ## RelabelConfigs to apply to samples before scraping
+  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+  ##
+  relabelings: []
+  # - sourceLabels: [__meta_kubernetes_pod_node_name]
+  #   separator: ;
+  #   regex: ^(.*)$
+  #   targetLabel: nodename
+  #   replacement: $1
+  #   action: replace
+
 probeNamespaceSelector: {}
 probeSelector: {}
 serviceMonitorNamespaceSelector: {}

--- a/helm/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/values.yaml
@@ -33,6 +33,26 @@ prometheus-agent:
 
   externalLabels: {}
 
+  serviceMonitor:
+    ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ##
+    metricRelabelings: []
+    # - action: keep
+    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+    #   sourceLabels: [__name__]
+
+    ## RelabelConfigs to apply to samples before scraping
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ##
+    relabelings: []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
+
   probeNamespaceSelector: {}
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}


### PR DESCRIPTION
This PR allows users to override the metricrelabelings and relabelings of the service monitor so we can relabel the app, node and container from the bundle