### PR TITLE
Upgrade prometheus 2.41.0 and support global.image.registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,17 +16,4 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-
-      - architect/push-to-app-catalog:
-          context: "architect"
-          executor: "app-build-suite"
-          name: push-to-giantswarm-playground-app-catalog
-          app_catalog: "giantswarm-playground-catalog"
-          app_catalog_test: "giantswarm-playground-test-catalog"
-          chart: "prometheus-agent"
-          # Trigger job on git tag.
-          filters:
-            tags:
-              only: /^v.*/
-
-                       
+        

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,19 @@ workflows:
       - architect/push-to-app-catalog:
           context: "architect"
           executor: "app-build-suite"
-          name: "package and push prometheus-agent chart"
+          name: push-to-default-app-catalog
+          app_catalog: "default-catalog"
+          app_catalog_test: "default-test-catalog"
+          chart: "prometheus-agent"
+          # Trigger job on git tag.
+          filters:
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-catalog:
+          context: "architect"
+          executor: "app-build-suite"
+          name: push-to-giantswarm-playground-app-catalog
           app_catalog: "giantswarm-playground-catalog"
           app_catalog_test: "giantswarm-playground-test-catalog"
           chart: "prometheus-agent"
@@ -16,3 +28,5 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+
+                       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,4 +16,3 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-        

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade prometheus from `2.40.5` to `2.41.0`
+- Add support for global.image.registry.
+
 ## [0.2.0] - 2023-02-06
 
 ### Added

--- a/helm/prometheus-agent/Chart.yaml
+++ b/helm/prometheus-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v2.40.5
+appVersion: v2.41.0
 name: prometheus-agent
 description: A Helm chart for Prometheus agent.
 dependencies:

--- a/helm/prometheus-agent/charts/prometheus-agent/Chart.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v2.40.5
+appVersion: v2.41.0
 name: prometheus-agent
 description: A Helm chart for Prometheus agent.
 home: https://github.com/giantswarm/prometheus-agent-app

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -41,9 +41,9 @@ spec:
     {{- toYaml $externalLabels | nindent 4 }}
   {{- end }}
   {{- if .Values.image.sha }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
+  image: "{{ .Values.global.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
   {{- else }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+  image: "{{ .Values.global.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
   {{- end }}
   # workaround - required to use an `exec command` livenessProbe.
   listenLocal: true

--- a/helm/prometheus-agent/charts/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/values.yaml
@@ -1,5 +1,8 @@
+global:
+  image:
+    registry: docker.io
+
 image:
-  registry: quay.io
   name: giantswarm/prometheus
   tag: ""
   sha: ""

--- a/helm/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/values.yaml
@@ -1,4 +1,6 @@
 global:
+  image:
+    registry: docker.io
   remoteWrite: []
   # - name: ""     # Name of the remote write integration
   #   url: ""      # URL to send data to
@@ -14,7 +16,6 @@ global:
 
 prometheus-agent:
   image:
-    registry: quay.io
     name: giantswarm/prometheus
     tag: ""
     sha: ""


### PR DESCRIPTION
This PR:

- upgrades prometheus to 2.41.0
- adds support for global.image.registry

Towards https://github.com/giantswarm/giantswarm/issues/26238 and https://github.com/giantswarm/roadmap/issues/2146

Will test on giraffe tomorrow

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Test on Workload cluster.
