### PR TITLE
set scrapeInterval to 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- set scrapeInterval configurable via values
+- change default scrapeInterval from 30s to 60s
+
 ## [0.3.0] - 2023-03-22
 
 ### Changed

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -100,6 +100,7 @@ spec:
   remoteWrite: []
 {{- end }}
   retention: 10d
+  scrapeInterval: {{ .Values.scrapeInterval }}
   securityContext:
     {{- toYaml  .Values.securityContext | nindent 4 }}
   serviceAccountName: {{ include "name" .}}

--- a/helm/prometheus-agent/charts/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/values.yaml
@@ -53,6 +53,8 @@ serviceMonitorSelector: {}
 podMonitorNamespaceSelector: {}
 podMonitorSelector: {}
 
+scrapeInterval: 60s
+
 securityContext:
   fsGroup: 2000
   runAsGroup: 2000


### PR DESCRIPTION
This PR:

- makes scrapeInterval configurable via values
- changes default scrapeInterval from 30s to 60s

Towards https://github.com/giantswarm/giantswarm/issues/25956

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Test on Workload cluster.
