### PR TITLE
preStop hook added to clean the agent wal before the container be killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `preStop` hook added to clean the agent wal before the container be killed
 - set scrapeInterval configurable via values
 - change default scrapeInterval from 30s to 60s
 

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -22,6 +22,13 @@ spec:
       name: http-web
       protocol: TCP
     {{- if .Values.watchdog.enabled }}
+    lifecycle:                                                                                                                                                                                                                                                
+      preStop:                                                                                                                                                                                                                                                
+        exec:                                                                                                                  
+          command:                                                                                                             
+          - /bin/sh                                                                                                            
+          - -c                                                                                                                 
+          - rm -f /prometheus/wal/*                                                                                            
     livenessProbe:
       exec:
         command:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26629

The watchdog recently added to kill the agent when it can't sent data to the prometheus, is not cleaning its wal before being killed.
We added a preStop hook to the container to clean the wal in that case.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Test on MC 
