### PR TITLE
Fix preStop with removing the entire wal directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix preStop with removing the entire wal directory.
+
 ## [0.4.0] - 2023-04-20
 
 ### Changed

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -28,7 +28,7 @@ spec:
           command:                                                                                                             
           - /bin/sh                                                                                                            
           - -c                                                                                                                 
-          - rm -f /prometheus/wal/*                                                                                            
+          - rm -rf /prometheus/wal
     livenessProbe:
       exec:
         command:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/26674

Fix preStop hook: removing the wal directory

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Test on Workload cluster.
