### PR TITLE
Add extra configurability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add more options to configure the agent (prometheus versions, retention, replicas, shards and so on).
+
 ## [0.4.1] - 2023-04-21
 
 ### Fixed

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -54,6 +54,9 @@ spec:
   {{- end }}
   # workaround - required to use an `exec command` livenessProbe.
   listenLocal: true
+  podMetadata:
+    labels:
+      {{ include "labels.common" . | nindent 6 }}
 {{- if .Values.podMonitorNamespaceSelector }}
   podMonitorNamespaceSelector:
     {{- toYaml  .Values.podMonitorNamespaceSelector | nindent 4 }}
@@ -106,7 +109,8 @@ spec:
 {{- else }}
   remoteWrite: []
 {{- end }}
-  retention: 10d
+  replicas: {{ .Values.replicas }}
+  retention: {{ .Values.retention }}
   scrapeInterval: {{ .Values.scrapeInterval }}
   securityContext:
     {{- toYaml  .Values.securityContext | nindent 4 }}
@@ -123,7 +127,5 @@ spec:
 {{ else }}
   serviceMonitorSelector: {}
 {{- end }}
-  podMetadata:
-    labels:
-      {{ include "labels.common" . | nindent 6 }}
-  version: {{ .Values.image.tag | default .Chart.AppVersion }}
+  shards: {{ .Values.shards }}
+  version: {{ default .Values.image.tag .Values.version | default .Chart.AppVersion }}

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/psp-rbac.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/psp-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{ if .Values.psp.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -29,4 +30,5 @@ roleRef:
   kind: ClusterRole
   name: {{ include "psp.name" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/psp.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{ if .Values.psp.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -34,4 +35,5 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+{{- end }}
 {{- end }}

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/servicemonitor.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/servicemonitor.yaml
@@ -15,24 +15,24 @@ spec:
     matchNames:
       - {{ .Release.Namespace }}
   endpoints:
-  - interval: 30s
+  - interval: {{ .Values.serviceMonitor.scrapeInterval }}
     port: web
-{{- if .Values.serviceMonitor.metricRelabelings }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ tpl (toYaml .Values.serviceMonitor.metricRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.serviceMonitor.relabelings }}
+    {{ tpl (toYaml .Values.serviceMonitor.metricRelabelings | nindent 4) . }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
     relabelings:
-{{ tpl (toYaml .Values.serviceMonitor.relabelings | indent 4) . }}
-{{- end }}
-  - interval: 30s
+    {{ tpl (toYaml .Values.serviceMonitor.relabelings | nindent 4) . }}
+    {{- end }}
+  - interval: {{ .Values.serviceMonitor.scrapeInterval }}
     port: reloader-web
-{{- if .Values.serviceMonitor.metricRelabelings }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ tpl (toYaml .Values.serviceMonitor.metricRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.serviceMonitor.relabelings }}
+    {{ tpl (toYaml .Values.serviceMonitor.metricRelabelings | nindent 4) . }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
     relabelings:
-{{ tpl (toYaml .Values.serviceMonitor.relabelings | indent 4) . }}
-{{- end }}
+    {{ tpl (toYaml .Values.serviceMonitor.relabelings | nindent 4) . }}
+    {{- end }}
 {{- end }}

--- a/helm/prometheus-agent/charts/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/values.yaml
@@ -22,6 +22,11 @@ remoteWrite: []
 #   tlsConfig:
 #     insecureSkipVerify: false
 
+replicas: 1
+shards: 1
+
+retention: 10d
+
 externalLabels: {}
 
 serviceMonitor:

--- a/helm/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/values.yaml
@@ -35,7 +35,14 @@ prometheus-agent:
   #   tlsConfig:
   #     insecureSkipVerify: false
 
+  replicas: 1
+  shards: 1
+
+  retention: 10d
+
   externalLabels: {}
+
+  version: ""
 
   serviceMonitor:
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.


### PR DESCRIPTION
This PR:

- adds more configurability so we can shard prometheus agents https://github.com/giantswarm/roadmap/issues/2419
- allow override of prometheus version and retention
- ensure we do not install psps in kubernetes 1.25+
- allow templetization of a few more properties


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Test on Workload cluster.
