### PR TITLE
Add safe to evict annotation to the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make the prometheus agent evictable by the cluster-autoscaler.
+
 ## [0.5.1] - 2023-05-06
 
 ### Fixed

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -55,6 +55,8 @@ spec:
   # workaround - required to use an `exec command` livenessProbe.
   listenLocal: true
   podMetadata:
+    annotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     labels:
       {{ include "labels.common" . | nindent 6 }}
 {{- if .Values.podMonitorNamespaceSelector }}


### PR DESCRIPTION
This PR:

- adds safe to evict annotation

Towards  https://github.com/giantswarm/giantswarm/issues/26883

Supersedes https://github.com/giantswarm/prometheus-agent-app/pull/57


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Test on Workload cluster.
