### PR TITLE
Remove prometheus and prometheus_replica labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove prometheus and prometheus_replica external label to avoid exponential growth in metrics in big clusters.
+
 ## [0.5.3] - 2023-05-17
 
 ### Fixed

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -84,6 +84,7 @@ spec:
 {{- else }}
   probeSelector: {}
 {{- end }}
+  prometheusExternalLabelName: ""
 {{- if $remoteWrites }}
   remoteWrite:
   {{- range $remoteWrite := $remoteWrites }}
@@ -113,6 +114,7 @@ spec:
   remoteWrite: []
 {{- end }}
   replicas: {{ .Values.replicas }}
+  replicaExternalLabelName: ""
   retention: {{ .Values.retention }}
   scrapeInterval: {{ .Values.scrapeInterval }}
   securityContext:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27684

This PR:

- fixes the prometheus agent app by removing the `prometheus` and `prometheus_replica` external labels added by the agent as they causes exponential growth in prometheus on really big clusters


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Test on Workload cluster.
