### PR TITLE
add anti-affinity to pods so that shards don't get scheduled on the s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add anti-affinity in the Prometheus CR to avoid prometheus-agent shards from being scheduled on the same node if possible.
+
 ## [0.5.4] - 2023-07-31
 
 ### Fixed

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -8,6 +8,17 @@ metadata:
   name: {{ include "name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: operator.prometheus.io/name
+              operator: In
+              values:
+              - prometheus-agent
   containers:
   - args:
     - --config.file=/etc/prometheus/config_out/prometheus.env.yaml

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -19,6 +19,7 @@ spec:
               operator: In
               values:
               - prometheus-agent
+          topologyKey: topology.kubernetes.io/zone
   containers:
   - args:
     - --config.file=/etc/prometheus/config_out/prometheus.env.yaml

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -19,7 +19,7 @@ spec:
               operator: In
               values:
               - prometheus-agent
-          topologyKey: topology.kubernetes.io/zone
+          topologyKey: kubernetes.io/hostname
   containers:
   - args:
     - --config.file=/etc/prometheus/config_out/prometheus.env.yaml


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27744

This PR:

- adds anti-affinity in the Prometheus CR so that prometheus-agent shards don't get scheduled on the same node if possible.


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Test on Workload cluster.
