### PR TITLE
update watchdog output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change watchdog output
+
 ## [0.6.3] - 2023-09-21
 
 ### Changed


### PR DESCRIPTION
Change watchdog output to fit nicer into k8s events

### Before

```
Events:
  Type     Reason     Age   From     Message
  ----     ------     ----  ----     -------
  Warning  Unhealthy  54m   kubelet  Liveness probe failed: Desired shards: 115 / max 10
ERROR - watchdog.sh: Overloaded - 115 desired chards for max 10 shards
  Normal   Pulled           54m (x5 over 3h45m)   kubelet       Container image "docker.io/giantswarm/prometheus:v2.47.0" already present on machine
  Warning  Unhealthy        54m (x2 over 54m)     kubelet       Readiness probe errored: rpc error: code = NotFound desc = failed to exec in container: failed to load task: no running task found: task d77ca4eb82d2f99ccc5342935b59e4f262bc0a917796aa8a9c2cf54da5bbd7a2 not found: not found
  Warning  Unhealthy        54m (x2 over 54m)     kubelet       Liveness probe errored: rpc error: code = NotFound desc = failed to exec in container: failed to load task: no running task found: task d77ca4eb82d2f99ccc5342935b59e4f262bc0a917796aa8a9c2cf54da5bbd7a2 not found: not found
  Normal   Created          54m (x5 over 3h45m)   kubelet       Created container prometheus
  Normal   Started          54m (x5 over 3h45m)   kubelet       Started container prometheus
  Warning  Unhealthy        53m (x3 over 53m)     kubelet       Startup probe failed: wget: server returned error: HTTP/1.1 503 Service Unavailable
  Warning  Unhealthy        47m (x16 over 3h45m)  kubelet       Liveness probe failed: ERROR - watchdog.sh: could not determine desired shards
  Warning  PolicyViolation  46m                   kyverno-scan  policy disallow-non-harbor-images-audit/disallow-non-harbor-images fail: validation failure: Images may only come from the following trusted harbor registries: registry.tools.3stripes.net registry.tools.adidas.com.cn registry-secondary.tools.adidas.com.cn
  Warning  PolicyViolation  41m                   kyverno-scan  policy disallow-non-harbor-images-audit/disallow-non-harbor-images fail: validation failure: Images may only come from the following trusted harbor registries: registry.tools.3stripes.net registry.tools.adidas.com.cn registry-secondary.tools.adidas.com.cn
  Warning  Unhealthy        38m (x2 over 38m)     kubelet       Liveness probe failed: Desired shards: 84 / max 10
ERROR - watchdog.sh: Overloaded - 84 desired chards for max 10 shards
  Warning  Unhealthy  2s  kubelet  Liveness probe failed: Desired shards: 126 / max 10
ERROR - watchdog.sh: Overloaded - 126 desired chards for max 10 shards
```

### After

// to be tested