### PR TITLE
Raise WATCHDOG_OVERLOAD_TOLERANCE from 2 to 5 to be more tolerant on desired shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raise WATCHDOG_OVERLOAD_TOLERANCE from 2 to 5 to be more tolerant on desired shards.
+ 
 ## [0.6.3] - 2023-09-21
 
 ### Changed

--- a/helm/prometheus-agent/Chart.yaml
+++ b/helm/prometheus-agent/Chart.yaml
@@ -4,7 +4,7 @@ name: prometheus-agent
 description: A Helm chart for Prometheus agent.
 dependencies:
   - name: prometheus-agent
-    version: 0.6.2
+    version: 0.6.3
 home: https://github.com/giantswarm/prometheus-agent-app
 kubeVersion: ">=1.19.0-0"
 sources:

--- a/helm/prometheus-agent/Chart.yaml
+++ b/helm/prometheus-agent/Chart.yaml
@@ -4,12 +4,12 @@ name: prometheus-agent
 description: A Helm chart for Prometheus agent.
 dependencies:
   - name: prometheus-agent
-    version: 0.6.3
+    version: 0.6.4
 home: https://github.com/giantswarm/prometheus-agent-app
 kubeVersion: ">=1.19.0-0"
 sources:
   - https://github.com/giantswarm/prometheus-agent-app
-version: 0.6.3
+version: 0.6.4
 annotations:
   application.giantswarm.io/team: atlas
 restrictions:

--- a/helm/prometheus-agent/charts/prometheus-agent/Chart.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/Chart.yaml
@@ -5,6 +5,6 @@ description: A Helm chart for Prometheus agent.
 home: https://github.com/giantswarm/prometheus-agent-app
 sources:
   - https://github.com/giantswarm/prometheus-agent-app
-version: 0.6.3
+version: 0.6.4
 annotations:
   application.giantswarm.io/team: atlas

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -113,7 +113,7 @@ spec:
     {{- if $remoteWrite.proxyUrl }}
     proxyUrl: {{ $remoteWrite.proxyUrl }}
     {{- end }}
-    remoteTimeout: {{ $remoteWrite.remoteTimeout | default 60s }}
+    remoteTimeout: {{ $remoteWrite.remoteTimeout | default "60s" }}
     url: {{ $remoteWrite.url }}
 {{- if $remoteWrite.tlsConfig }}
     tlsConfig:

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -113,7 +113,7 @@ spec:
     {{- if $remoteWrite.proxyUrl }}
     proxyUrl: {{ $remoteWrite.proxyUrl }}
     {{- end }}
-    remoteTimeout: {{ $remoteWrite.remoteTimeout }}
+    remoteTimeout: {{ $remoteWrite.remoteTimeout | default 60s }}
     url: {{ $remoteWrite.url }}
 {{- if $remoteWrite.tlsConfig }}
     tlsConfig:

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -113,7 +113,7 @@ spec:
     {{- if $remoteWrite.proxyUrl }}
     proxyUrl: {{ $remoteWrite.proxyUrl }}
     {{- end }}
-    remoteTimeout: 30s
+    remoteTimeout: {{ $remoteWrite.remoteTimeout }}
     url: {{ $remoteWrite.url }}
 {{- if $remoteWrite.tlsConfig }}
     tlsConfig:

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -49,7 +49,7 @@ spec:
         {{- else }}
         - /bin/sh
         - -c
-        - WATCHDOG_OVERLOAD_TOLERANCE=5 sh /etc/prometheus/configmaps/prometheus-agent-watchdog/watchdog.sh
+        - WATCHDOG_OVERLOAD_TOLERANCE={{ .Values.watchdog.watchdogOverloadTolerance }} sh /etc/prometheus/configmaps/prometheus-agent-watchdog/watchdog.sh
         {{- end }}
     {{- end }}
   configMaps:

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -47,8 +47,9 @@ spec:
         {{- if .Values.watchdog.command }}
         {{- toYaml .Values.watchdog.command | nindent 8 }}
         {{- else }}
-        - sh
-        - /etc/prometheus/configmaps/prometheus-agent-watchdog/watchdog.sh
+        - /bin/sh
+        - -c
+        - WATCHDOG_OVERLOAD_TOLERANCE=5 sh /etc/prometheus/configmaps/prometheus-agent-watchdog/watchdog.sh
         {{- end }}
     {{- end }}
   configMaps:

--- a/helm/prometheus-agent/charts/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/values.yaml
@@ -75,6 +75,7 @@ psp:
 
 watchdog:
   enabled: true
+  watchdogOverloadTolerance: 5
   # command:
   #   - sh
   #   - /etc/prometheus/configmaps/prometheus-agent-watchdog/watchdog.sh

--- a/helm/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/values.yaml
@@ -113,7 +113,7 @@ prometheus-agent:
 
   watchdog:
     enabled: true
-    command:
-      # - WATCHDOG_OVERLOAD_TOLERANCE=4
-      - sh
-      - /etc/prometheus/configmaps/prometheus-agent-watchdog/watchdog.sh
+    watchdogOverloadTolerance: 5
+    # command:
+    #   - sh
+    #   - /etc/prometheus/configmaps/prometheus-agent-watchdog/watchdog.sh


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/28239

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Test on Workload cluster.
