### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.6.6] - 2023-10-30
 
 ### Added
@@ -32,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Raise WATCHDOG_OVERLOAD_TOLERANCE from 2 to 5 to be more tolerant on desired shards.
- 
+
 ## [0.6.3] - 2023-09-21
 
 ### Changed

--- a/helm/prometheus-agent/charts/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/values.yaml
@@ -11,24 +11,24 @@ image:
 affinity:
   nodeAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
-      - preference:
-          matchExpressions:
-            - key: karpenter.sh/capacity-type
-              operator: NotIn
-              values:
-                - spot
-        weight: 100
+    - preference:
+        matchExpressions:
+        - key: karpenter.sh/capacity-type
+          operator: NotIn
+          values:
+          - spot
+      weight: 100
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-              - key: operator.prometheus.io/name
-                operator: In
-                values:
-                  - prometheus-agent
-          topologyKey: kubernetes.io/hostname
-        weight: 50
+    - podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: operator.prometheus.io/name
+            operator: In
+            values:
+            - prometheus-agent
+        topologyKey: kubernetes.io/hostname
+      weight: 50
 
 keepDroppedTargets: 0
 

--- a/helm/prometheus-agent/charts/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/values.yaml
@@ -1,6 +1,6 @@
 global:
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
 
 image:
   name: giantswarm/prometheus
@@ -11,24 +11,24 @@ image:
 affinity:
   nodeAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
-    - preference:
-        matchExpressions:
-        - key: karpenter.sh/capacity-type
-          operator: NotIn
-          values:
-          - spot
-      weight: 100
+      - preference:
+          matchExpressions:
+            - key: karpenter.sh/capacity-type
+              operator: NotIn
+              values:
+                - spot
+        weight: 100
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
-    - podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: operator.prometheus.io/name
-            operator: In
-            values:
-            - prometheus-agent
-        topologyKey: kubernetes.io/hostname
-      weight: 50
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: operator.prometheus.io/name
+                operator: In
+                values:
+                  - prometheus-agent
+          topologyKey: kubernetes.io/hostname
+        weight: 50
 
 keepDroppedTargets: 0
 

--- a/helm/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/values.yaml
@@ -1,6 +1,6 @@
 global:
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
   remoteWrite: []
   # - name: ""     # Name of the remote write integration
   #   url: ""      # URL to send data to
@@ -24,24 +24,24 @@ prometheus-agent:
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - preference:
-          matchExpressions:
-          - key: karpenter.sh/capacity-type
-            operator: NotIn
-            values:
-            - spot
-        weight: 100
+        - preference:
+            matchExpressions:
+              - key: karpenter.sh/capacity-type
+                operator: NotIn
+                values:
+                  - spot
+          weight: 100
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: operator.prometheus.io/name
-              operator: In
-              values:
-              - prometheus-agent
-          topologyKey: kubernetes.io/hostname
-        weight: 50
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: operator.prometheus.io/name
+                  operator: In
+                  values:
+                    - prometheus-agent
+            topologyKey: kubernetes.io/hostname
+          weight: 50
 
   keepDroppedTargets: 0
 
@@ -86,19 +86,19 @@ prometheus-agent:
     relabelings:
       # Add app label.
       - sourceLabels:
-        - __meta_kubernetes_pod_label_app_kubernetes_io_name
+          - __meta_kubernetes_pod_label_app_kubernetes_io_name
         targetLabel: app
       # Add instance label.
       - sourceLabels:
-        - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+          - __meta_kubernetes_pod_label_app_kubernetes_io_instance
         targetLabel: instance
       # Add node label.
       - sourceLabels:
-        - __meta_kubernetes_pod_node_name
+          - __meta_kubernetes_pod_node_name
         targetLabel: node
       # Add team label.
       - sourceLabels:
-        - __meta_kubernetes_pod_label_application_giantswarm_io_team
+          - __meta_kubernetes_pod_label_application_giantswarm_io_team
         targetLabel: team
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
     #   separator: ;

--- a/helm/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/values.yaml
@@ -24,24 +24,24 @@ prometheus-agent:
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-        - preference:
-            matchExpressions:
-              - key: karpenter.sh/capacity-type
-                operator: NotIn
-                values:
-                  - spot
-          weight: 100
+      - preference:
+          matchExpressions:
+          - key: karpenter.sh/capacity-type
+            operator: NotIn
+            values:
+            - spot
+        weight: 100
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-        - podAffinityTerm:
-            labelSelector:
-              matchExpressions:
-                - key: operator.prometheus.io/name
-                  operator: In
-                  values:
-                    - prometheus-agent
-            topologyKey: kubernetes.io/hostname
-          weight: 50
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: operator.prometheus.io/name
+              operator: In
+              values:
+              - prometheus-agent
+          topologyKey: kubernetes.io/hostname
+        weight: 50
 
   keepDroppedTargets: 0
 
@@ -86,19 +86,19 @@ prometheus-agent:
     relabelings:
       # Add app label.
       - sourceLabels:
-          - __meta_kubernetes_pod_label_app_kubernetes_io_name
+        - __meta_kubernetes_pod_label_app_kubernetes_io_name
         targetLabel: app
       # Add instance label.
       - sourceLabels:
-          - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+        - __meta_kubernetes_pod_label_app_kubernetes_io_instance
         targetLabel: instance
       # Add node label.
       - sourceLabels:
-          - __meta_kubernetes_pod_node_name
+        - __meta_kubernetes_pod_node_name
         targetLabel: node
       # Add team label.
       - sourceLabels:
-          - __meta_kubernetes_pod_label_application_giantswarm_io_team
+        - __meta_kubernetes_pod_label_application_giantswarm_io_team
         targetLabel: team
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
     #   separator: ;


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
