### PR TITLE
Disable HTTP2 for remotewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Possibility to set `enableHTTP2` for remoteWrites
+
+### Changed
+
+- remoteWrites have HTTP2 disabled by default
+
 ## [0.6.7] - 2024-01-09
 
 ### Changed

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -103,6 +103,7 @@ spec:
         key: username
         name: {{ $remoteWrite.name }}-remote-write-api
     name: {{ $remoteWrite.name }}
+    enableHTTP2: {{ $remoteWrite.enableHTTP2 | default "false" }}
     {{- if $remoteWrite.proxyUrl }}
     proxyUrl: {{ $remoteWrite.proxyUrl }}
     {{- end }}

--- a/helm/prometheus-agent/charts/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/values.yaml
@@ -38,6 +38,7 @@ remoteWrite: []
 #   url: ""      # URL to send data to
 #   username: "" # Username to use
 #   password: "" # Password
+#   enableHTTP2: false
 #   # https://github.com/prometheus-community/prometheus-operator/blob/main/Documentation/api.md#queueconfig
 #   queueConfig:
 #     capacity: 30000


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29213

This PR:

- Adds the `enableHTTP2` key for remoteWrites
- Sets it to `false` by default

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Test on Workload cluster.
