### PR TITLE
tune agent's discovery scrape interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `scrape.discovery-reload-interval` as additional arg for the prometheus.
+
 ### Changed
 
 - Upgrade prometheus version to 2.51.1.

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -8,6 +8,12 @@ metadata:
   name: {{ include "name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.discovery.tuned }}
+  additionalArgs:
+  # -- Allow to tune the discovery scrape interval to save on resources usage. Default is 1s.
+  - name: scrape.discovery-reload-interval
+    value: {{ .Values.discovery.reloadInterval }}
+  {{- end }}
   {{- with .Values.affinity }}
   affinity:
     {{- toYaml . | nindent 4 -}}

--- a/helm/prometheus-agent/charts/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/values.yaml
@@ -32,6 +32,10 @@ affinity:
 
 keepDroppedTargets: 0
 
+discovery:
+  tuned: true
+  reloadInterval: 30s
+
 remoteWrite: []
 # - name: ""     # Name of the remote write integration
 #   proxyUrl: ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30830

This PR adds a field in the Prometheus CR allowing to tune the discovery scrape interval. If we set it at 30s for example (instead of the default 1s), it should help saving on resources usage.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Test on Workload cluster.
