### PR TITLE
Add support for extraArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for extraArgs for prometheus-agent
+
 ### Changed
 
 - Upgrade prometheus version to 2.51.1.

--- a/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
+++ b/helm/prometheus-agent/charts/prometheus-agent/templates/prometheus.yaml
@@ -19,6 +19,9 @@ spec:
     - --enable-feature=agent
     - --web.enable-lifecycle
     - --web.listen-address=:9090
+    {{- with .Values.extraArgs }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     name: prometheus
     # force exposition of port for monitoring
     ports:

--- a/helm/prometheus-agent/values.yaml
+++ b/helm/prometheus-agent/values.yaml
@@ -43,6 +43,8 @@ prometheus-agent:
           topologyKey: kubernetes.io/hostname
         weight: 50
 
+  extraArgs: []
+
   keepDroppedTargets: 0
 
   remoteWrite: []


### PR DESCRIPTION
This PR:
- add support for setting etraArgs for prometheus-agent from values

Towards https://github.com/giantswarm/giantswarm/issues/31559, but could also be useful for non-related config changes.


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Test on Workload cluster.
